### PR TITLE
Add apple runtime

### DIFF
--- a/code/meson.build
+++ b/code/meson.build
@@ -1,2 +1,7 @@
+if host_machine.system() == 'darwin'
+    add_languages('objc', native: false, required: true)
+    add_languages('objcpp', native: false, required: true)
+endif
+
 subdir('logic')
 subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -4,4 +4,5 @@ project('Fossil Media', 'c', 'cpp',
     version: '0.1.0',
     default_options: ['c_std=c17,c18', 'cpp_std=c++20'])
 
+
 subdir('code')


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description

This pull request adds basic Apple platform support for Objective-C and Objective-C++ allowing the existing libraries to be used in applications developed on Apple devices. Support for foundation framework is not guaranteed as the main focus is on the language itself and not on the frameworks.

## Testing
<!-- Describe the testing process or steps taken to ensure the changes work as expected. -->

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
